### PR TITLE
Show corresponding icon on request response

### DIFF
--- a/client/src/components/BreedForm.vue
+++ b/client/src/components/BreedForm.vue
@@ -23,32 +23,32 @@ form#breed-form
 			b-button.button.is-success(
 				@click='send()'
 			) {{ labelButtonAccept }}
-			b-message.message(
+			b-icon#success-icon(
 				title='Success'
 				type='is-success'
-				aria-close-label='Close message'
-				icon-pack='fas'
-				icon-size='is-medium'
+				pack='fas'
+				size='is-large'
 				icon='check'
-				has-icon
-				auto-close
-				v-if='status === 201 || status === 200'
+				v-if='status === OK || status === CREATED'
 			)
-			b-message.message(
+			b-icon#error-icon(
 				title='Error'
 				type='is-danger'
-				aria-close-label='Close message'
-				icon-pack='fas'
-				icon-size='is-medium'
+				pack='fas'
+				size='is-large'
 				icon='exclamation'
-				has-icon
-				auto-close
-				v-if='status === 401 || status === 404'
+				v-if='status === AUTH || status === NOT_FOUND || status === ERROR'
 			)
 </template>
 
 <script lang='js'>
 import axios from 'axios'
+
+export const OK = 200
+export const CREATED = 201
+export const AUTH = 401
+export const NOT_FOUND = 404
+export const ERROR = 406
 
 export default {
 	name: 'BreedForm',
@@ -61,6 +61,11 @@ export default {
 	},
 	data() {
 		return {
+			OK,
+			CREATED,
+			AUTH,
+			NOT_FOUND,
+			ERROR,
 			title: 'Create Breed',
 			labelButtonCancel: 'Cancel',
 			labelButtonAccept: 'Accept',

--- a/client/tests/unit/breed-form.spec.js
+++ b/client/tests/unit/breed-form.spec.js
@@ -64,7 +64,7 @@ describe('BreedForm Component', () => {
 	})
 
 	const modalFooter = modal.get('.modal-card-foot')
-	it('Should has a modal Foot', () => {
+	it('Should has a modal Foot', async () => {
 		expect(modalFooter.exists()).toBeTruthy()
 
 		const cancelButton = modalFooter.get('button')
@@ -74,22 +74,24 @@ describe('BreedForm Component', () => {
 		const acceptButton = modalFooter.get('b-button-stub')
 		expect(acceptButton.exists()).toBeTruthy()
 		expect(acceptButton.text()).toMatch(data.labelButtonAccept)
-	})
 
-	it('Should have a Success Messages on Create Success Status', async () => {
-		wrapper.setData({ status: 201 })
-		await wrapper.vm.$nextTick()
-		const successMessage = wrapper.get('b-message-stub')
-		expect(successMessage.attributes().title).toMatch('Success')
-		expect(successMessage.attributes().icon).toMatch('check')
-	})
+		await wrapper.setData({ status: 200 })
+		const successIcon = modalFooter.get('#success-icon')
+		expect(successIcon.exists()).toBeTruthy()
+		expect(successIcon.attributes().title).toMatch('Success')
+		expect(successIcon.attributes().type).toMatch('is-success')
+		expect(successIcon.attributes().pack).toMatch('fas')
+		expect(successIcon.attributes().size).toMatch('is-large')
+		expect(successIcon.attributes().icon).toMatch('check')
 
-	it('Should have an Error Messages on Create Error Status', async () => {
-		wrapper.setData({ status: 401 })
-		await wrapper.vm.$nextTick()
-		const errorMessage = wrapper.get('b-message-stub')
-		expect(errorMessage.attributes().title).toMatch('Error')
-		expect(errorMessage.attributes().icon).toMatch('exclamation')
+		await wrapper.setData({ status: 401 })
+		const errorIcon = modalFooter.get('#error-icon')
+		expect(errorIcon.exists()).toBeTruthy()
+		expect(errorIcon.attributes().title).toMatch('Error')
+		expect(errorIcon.attributes().type).toMatch('is-danger')
+		expect(errorIcon.attributes().pack).toMatch('fas')
+		expect(errorIcon.attributes().size).toMatch('is-large')
+		expect(errorIcon.attributes().icon).toMatch('exclamation')
 	})
 
 	it('Should has an init method', () => {


### PR DESCRIPTION
## Description
Now when we click in the accept button inside Breed Form an icon it shown in success or error.

Fixes #9 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] breed-form.spec.js

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings